### PR TITLE
AvaloniaResource

### DIFF
--- a/Source/OxyPlot.Avalonia/OxyPlot.Avalonia.csproj
+++ b/Source/OxyPlot.Avalonia/OxyPlot.Avalonia.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.xaml;Assets\*" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
+    <AvaloniaResource Include="**\*.xaml;Assets\*;" Exclude="bin\**;obj\**;**\*.xproj;packages\**;@(EmbeddedResource)" />
     <PackageReference Include="Avalonia" Version="0.10.7" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
   </ItemGroup>


### PR DESCRIPTION
This will (hopefully) allow importing styles with `avares` instead of 'resm'

Rider does not like resm imports, and throw exceptions because of them.
![image](https://user-images.githubusercontent.com/25281882/145400201-f157996c-29ef-48ef-be8d-dd7027ea9ff3.png)
